### PR TITLE
fix(valkey_redis): shield consume against drain_events cancellation

### DIFF
--- a/kombu/transport/valkey_redis.py
+++ b/kombu/transport/valkey_redis.py
@@ -746,7 +746,11 @@ class Channel:
         to avoid BZMPOP blocking.
         """
         if self._consume_fast_mode or timeout == 0:
-            result = await self._fast_consume(queues)
+            # Shield: once the Lua script is dispatched it atomically pops the
+            # message and bumps messages_index server-side. If cancelled
+            # mid-flight the payload would be lost and the message stranded
+            # until visibility-timeout restore (~6 min).
+            result = await asyncio.shield(self._fast_consume(queues))
             if result:
                 return True
             if timeout == 0:
@@ -755,7 +759,8 @@ class Channel:
             # FAST returned nil — all queues empty, switch to SLOW
             self._consume_fast_mode = False
 
-        # SLOW mode: blocking BZMPOP
+        # SLOW mode: blocking BZMPOP. _slow_consume shields its own
+        # post-BZMPOP finalisation; BZMPOP itself stays cancellable.
         delivered = await self._slow_consume(queues, timeout)
         if delivered:
             self._consume_fast_mode = True  # Switch back to FAST
@@ -815,6 +820,11 @@ class Channel:
         if not result:
             return False
 
+        # BZMPOP has popped the delivery tag from the queue ZSET. From here on
+        # the consume must run to completion or the message is stranded.
+        return await asyncio.shield(self._slow_consume_finalize(result))
+
+    async def _slow_consume_finalize(self, result) -> bool:
         queue_key_raw, members = result
         queue_key = queue_key_raw.decode() if isinstance(queue_key_raw, bytes) else queue_key_raw
         queue_key = self._unprefixed(queue_key)

--- a/tests/unit/transport/test_valkey_redis.py
+++ b/tests/unit/transport/test_valkey_redis.py
@@ -531,6 +531,95 @@ class TestFastSlowConsume:
         msg = call_args[0][1]
         assert msg.headers.get("x-restore-count") == 3
 
+    async def test_consume_regular_delivers_when_cancelled_during_fast_script(self):
+        # The FAST Lua script atomically pops from the queue ZSET and bumps the
+        # messages_index score server-side. If drain_events cancels the consume
+        # task while the reply is in flight, the payload is discarded and the
+        # message strands in messages_index until visibility-timeout restore
+        # fires ~6 min later. Verify the message is still delivered.
+        ch = _make_channel()
+        ch._consume_fast_mode = True
+
+        cb = MagicMock()
+        ch._consumers["tag1"] = ("q1", cb, True)
+
+        script_called = asyncio.Event()
+
+        async def _script(*args, **kwargs):
+            script_called.set()
+            # Yield so the outer task can be cancelled while we're awaiting.
+            await asyncio.sleep(0.01)
+            return [
+                b"q1",
+                b"dt1",
+                b'{"body": "hi", "properties": {}, "headers": {}}',
+                b"0",
+            ]
+
+        ch._consume_script = _script
+
+        task = asyncio.create_task(ch._consume_regular(["q1"], timeout=1.0))
+        await script_called.wait()
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+        # Wait for the shielded inner FAST consume to finish delivery.
+        for _ in range(200):
+            if cb.called:
+                break
+            await asyncio.sleep(0.005)
+        assert cb.called, "message stranded: not delivered after cancellation"
+
+    async def test_consume_regular_delivers_when_cancelled_after_bzmpop(self):
+        # In SLOW mode, BZMPOP pops the delivery tag from the queue ZSET before
+        # the pipeline refreshes the index and fetches the payload. Cancellation
+        # in that window strands the message — the finalize step must complete.
+        ch = _make_channel()
+        ch._consume_fast_mode = False
+
+        cb = MagicMock()
+        ch._consumers["tag1"] = ("q1", cb, True)
+
+        ch.client.bzmpop = AsyncMock(return_value=(b"queue:q1", [(b"dt1", 1000.0)]))
+
+        execute_called = asyncio.Event()
+
+        async def _execute():
+            execute_called.set()
+            await asyncio.sleep(0.01)
+            return [None, [b'{"body": "hi", "properties": {}, "headers": {}}', b"0"]]
+
+        mock_pipe = AsyncMock()
+        mock_pipe.zadd = AsyncMock()
+        mock_pipe.hmget = AsyncMock()
+        mock_pipe.execute = _execute
+
+        class PipeCtx:
+            async def __aenter__(self):
+                return mock_pipe
+
+            async def __aexit__(self, *a):
+                pass
+
+        ch.client.pipeline = MagicMock(return_value=PipeCtx())
+
+        task = asyncio.create_task(ch._consume_regular(["q1"], timeout=1.0))
+        await execute_called.wait()
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+        for _ in range(200):
+            if cb.called:
+                break
+            await asyncio.sleep(0.005)
+        assert cb.called, "message stranded: not delivered after cancellation"
+
 
 # ---------------------------------------------------------------------------
 # Ack / Reject / Recover


### PR DESCRIPTION
## Summary

The benchmark in [celery-asyncio/examples/benchmark/RESULTS.md](https://github.com/oliverhaas/celery-asyncio/blob/main/examples/benchmark/RESULTS.md) flagged that the asyncio Redis transport strands 0.07–0.16 % of task messages (21–48 of 30 000) during heavy workloads. Root cause was a cancellation race in `Channel._consume_regular`:

- **FAST path**: the Lua script atomically ZPOPMIN's the message and bumps `messages_index` server-side to `now + visibility_timeout + RCI` (~360 s). If `drain_events` cancels the consume task between request-sent and reply-received, the payload is discarded — the message sits in `messages_index` until visibility-timeout restore re-enqueues it ~6 min later.
- **SLOW path**: same shape — BZMPOP pops from the queue ZSET, then the pipeline ZADD-XX + HMGET runs. Cancellation between BZMPOP returning and `_deliver_to_consumer` running strands the message similarly.

Fix wraps both critical sections in `asyncio.shield`:
- Shield the whole `_fast_consume` call (the Lua script is non-blocking).
- Split `_slow_consume` so BZMPOP stays cancellable, and shield the post-BZMPOP finalize step.

If `drain_events` cancels, `_consume_regular` raises `CancelledError` as before, but the shielded inner task continues and delivers the message to its consumer.

## Test plan
- [x] New unit tests reproduce the stranding for FAST (cancel during script reply) and SLOW (cancel during pipeline) — verified RED without the fix, GREEN with it
- [x] Full `tests/unit/` suite passes (225 passed, 1 skipped)
- [ ] Re-run `celery-asyncio` benchmark against the patched kombu-asyncio and confirm `n_stranded` drops to 0