### PR TITLE
fix(valkey_redis): make consumer iterations long-lived to stop stranding messages

### DIFF
--- a/kombu/transport/valkey_redis.py
+++ b/kombu/transport/valkey_redis.py
@@ -98,22 +98,23 @@ DEFAULT_MESSAGE_TTL = -1
 MIN_QUEUE_EXPIRES = 10_000
 DEFAULT_MAX_RESTORE_COUNT: int | None = None
 
-# Server-side block duration for BZMPOP/XREAD inside a single consumer
-# iteration. Bounds graceful-close latency and the maximum delay before a
-# newly registered consumer's queue starts being polled.
-BROKER_BLOCK_TIMEOUT = 1.0
+# Default server-side block duration for BZMPOP/XREAD inside a single consumer
+# iteration. Same shape as classic kombu's `brpop_timeout` transport option.
+# Overridable via the `brpop_timeout` transport option.
+DEFAULT_BRPOP_TIMEOUT = 10.0
 
-# asyncio.wait safety net for the consumer iteration. We trust Redis to honour
-# BZMPOP/XREAD BLOCK reliably, so this is only ever supposed to fire if the
-# client connection or server has truly hung. Set far above BROKER_BLOCK_TIMEOUT
-# so it does not race normal completions.
-CONSUMER_WAIT_SAFETY_TIMEOUT = 30.0
+# Additional headroom layered on top of the configured `brpop_timeout` for the
+# asyncio.wait safety net. We trust Redis to honour BLOCK and return within
+# brpop_timeout; the safety net only fires if the client connection or server
+# has hung beyond brpop_timeout + this headroom.
+CONSUMER_WAIT_HEADROOM = 30.0
 
-# Maximum time close() will wait for in-flight iterations to drain naturally
-# before cancelling them as a last resort. Cancellation during close may
-# strand a message, but visibility-timeout restore recovers them on next
-# worker startup.
-CLOSE_DRAIN_TIMEOUT = BROKER_BLOCK_TIMEOUT * 3
+# Additional headroom layered on top of `brpop_timeout` for close()'s graceful
+# drain. The iteration should complete within brpop_timeout; we give it a small
+# extra window before cancelling as a last resort. Cancellation during close
+# may strand a message, but visibility-timeout restore recovers them on the
+# next worker startup.
+CLOSE_DRAIN_HEADROOM = 2.0
 
 DEFAULT_EXCHANGE = ""
 DEFAULT_FANOUT_PREFIX = "/{db}."
@@ -252,11 +253,15 @@ class Channel:
         # FAST/SLOW consume mode
         self._consume_fast_mode: bool = True
 
+        # Server-side block duration for BZMPOP/XREAD inside a single consumer
+        # iteration. Matches classic kombu's `brpop_timeout` option.
+        self._brpop_timeout: float = opts.get("brpop_timeout", DEFAULT_BRPOP_TIMEOUT)
+
         # Long-lived consumer iteration tasks; created lazily by drain_events.
         # Each task runs a single FAST→SLOW (or XREAD) cycle bounded by
-        # BROKER_BLOCK_TIMEOUT, then exits. drain_events restarts them.
-        # They are never cancelled in the hot path; close() sets _closing and
-        # awaits them to drain naturally.
+        # `_brpop_timeout`, then exits. drain_events restarts them. They are
+        # never cancelled in the hot path; close() sets _closing and awaits
+        # them to drain naturally.
         self._consume_iter_task: asyncio.Task | None = None
         self._xread_iter_task: asyncio.Task | None = None
         self._closing: bool = False
@@ -706,12 +711,10 @@ class Channel:
         consumers.
 
         Consumer iterations are long-lived and bounded by Redis-side
-        BROKER_BLOCK_TIMEOUT — never cancelled mid-flight. They complete on
-        their own well before CONSUMER_WAIT_SAFETY_TIMEOUT, which is a generous
-        safety net that only fires if the client connection or server has hung.
-        The caller's `timeout` parameter only affects the timeout=0 non-blocking
-        fast path; in the blocking path, drain_events returns when the current
-        iteration completes (typically within BROKER_BLOCK_TIMEOUT seconds).
+        `brpop_timeout` — never cancelled mid-flight. They complete on their
+        own; the asyncio.wait safety net at `brpop_timeout + CONSUMER_WAIT_HEADROOM`
+        only fires if the client connection or server has hung. The caller's
+        `timeout` parameter only affects the timeout=0 non-blocking fast path.
         """
         if self._closing or not self._consumers:
             await asyncio.sleep(0.1)
@@ -736,10 +739,11 @@ class Channel:
             await asyncio.sleep(0.1)
             return False
 
+        safety_timeout = self._brpop_timeout + CONSUMER_WAIT_HEADROOM
         done, _pending = await asyncio.wait(
             tasks,
             return_when=asyncio.FIRST_COMPLETED,
-            timeout=CONSUMER_WAIT_SAFETY_TIMEOUT,
+            timeout=safety_timeout,
         )
 
         if not done:
@@ -749,9 +753,12 @@ class Channel:
             # delivered. The iteration is left pending; if Redis recovers it
             # completes naturally and the next drain_events call picks it up.
             logger.warning(
-                "consumer iteration did not return within %.1fs — Redis "
-                "BLOCK reply may be stalled; leaving iteration pending",
-                CONSUMER_WAIT_SAFETY_TIMEOUT,
+                "consumer iteration did not return within %.1fs (brpop_timeout=%.1fs "
+                "+ headroom=%.1fs) — Redis BLOCK reply may be stalled; leaving "
+                "iteration pending",
+                safety_timeout,
+                self._brpop_timeout,
+                CONSUMER_WAIT_HEADROOM,
             )
             return False
 
@@ -796,19 +803,19 @@ class Channel:
 
     async def _safe_consume_iter(self, queues: list[str]) -> bool:
         try:
-            return await self._consume_regular(queues, BROKER_BLOCK_TIMEOUT)
+            return await self._consume_regular(queues, self._brpop_timeout)
         except Exception as exc:
             logger.debug("consume iteration error: %s", exc)
             # Back off so drain_events doesn't tight-loop on a persistent fault.
-            await asyncio.sleep(min(BROKER_BLOCK_TIMEOUT, 0.1))
+            await asyncio.sleep(min(self._brpop_timeout, 0.1))
             return False
 
     async def _safe_xread_iter(self) -> bool:
         try:
-            return await self._xread_wait(BROKER_BLOCK_TIMEOUT)
+            return await self._xread_wait(self._brpop_timeout)
         except Exception as exc:
             logger.debug("xread iteration error: %s", exc)
-            await asyncio.sleep(min(BROKER_BLOCK_TIMEOUT, 0.1))
+            await asyncio.sleep(min(self._brpop_timeout, 0.1))
             return False
 
     async def _consume_regular(self, queues: list[str], timeout: float) -> bool:
@@ -1360,30 +1367,34 @@ class Channel:
         self._closing = True
 
         # Let consumer iterations finish naturally — bounded by
-        # BROKER_BLOCK_TIMEOUT. They are never cancelled in the hot path, so
-        # any in-flight FAST script / BZMPOP finalisation runs to completion
-        # and the message is delivered rather than stranded in messages_index.
+        # `brpop_timeout`. They are never cancelled in the hot path, so any
+        # in-flight FAST script / BZMPOP finalisation runs to completion and
+        # the message is delivered rather than stranded in messages_index.
         # If an iteration is hung (Redis unresponsive), we cancel it after
-        # CLOSE_DRAIN_TIMEOUT as a last resort: stranding at shutdown is
-        # acceptable since visibility-timeout restore recovers those messages
-        # on the next worker startup.
+        # `brpop_timeout + CLOSE_DRAIN_HEADROOM` as a last resort: stranding
+        # at shutdown is acceptable since visibility-timeout restore recovers
+        # those messages on the next worker startup.
         consumer_tasks = [
             t
             for t in (self._consume_iter_task, self._xread_iter_task)
             if t is not None and not t.done()
         ]
         if consumer_tasks:
+            drain_timeout = self._brpop_timeout + CLOSE_DRAIN_HEADROOM
             try:
                 await asyncio.wait_for(
                     asyncio.gather(*consumer_tasks, return_exceptions=True),
-                    timeout=CLOSE_DRAIN_TIMEOUT,
+                    timeout=drain_timeout,
                 )
             except (TimeoutError, asyncio.TimeoutError):
                 logger.warning(
-                    "consumer iterations did not drain within %.1fs at close; "
-                    "cancelling — in-flight messages may be stranded until "
-                    "visibility-timeout restore",
-                    CLOSE_DRAIN_TIMEOUT,
+                    "consumer iterations did not drain within %.1fs at close "
+                    "(brpop_timeout=%.1fs + headroom=%.1fs); cancelling — "
+                    "in-flight messages may be stranded until visibility-"
+                    "timeout restore",
+                    drain_timeout,
+                    self._brpop_timeout,
+                    CLOSE_DRAIN_HEADROOM,
                 )
                 for task in consumer_tasks:
                     if not task.done():

--- a/kombu/transport/valkey_redis.py
+++ b/kombu/transport/valkey_redis.py
@@ -35,6 +35,7 @@ Transport Options
 * ``stream_maxlen``: Maximum stream length for fanout streams (default: 10000)
 * ``fanout_prefix``: Prefix for fanout stream keys (default: '/{db}.')
 * ``max_restore_count``: Max times a message can be restored before being dropped (None = no limit)
+* ``block_timeout``: Server-side BZMPOP/XREAD BLOCK duration per consumer iteration in seconds (default: 10)
 * ``credential_provider``: A CredentialProvider instance or dotted import path
 * ``socket_timeout``: Socket timeout in seconds
 * ``socket_connect_timeout``: Socket connection timeout in seconds
@@ -99,18 +100,17 @@ MIN_QUEUE_EXPIRES = 10_000
 DEFAULT_MAX_RESTORE_COUNT: int | None = None
 
 # Default server-side block duration for BZMPOP/XREAD inside a single consumer
-# iteration. Same shape as classic kombu's `brpop_timeout` transport option.
-# Overridable via the `brpop_timeout` transport option.
-DEFAULT_BRPOP_TIMEOUT = 10.0
+# iteration. Overridable via the `block_timeout` transport option.
+DEFAULT_BLOCK_TIMEOUT = 10.0
 
-# Additional headroom layered on top of the configured `brpop_timeout` for the
+# Additional headroom layered on top of the configured `block_timeout` for the
 # asyncio.wait safety net. We trust Redis to honour BLOCK and return within
-# brpop_timeout; the safety net only fires if the client connection or server
-# has hung beyond brpop_timeout + this headroom.
+# block_timeout; the safety net only fires if the client connection or server
+# has hung beyond block_timeout + this headroom.
 CONSUMER_WAIT_HEADROOM = 30.0
 
-# Additional headroom layered on top of `brpop_timeout` for close()'s graceful
-# drain. The iteration should complete within brpop_timeout; we give it a small
+# Additional headroom layered on top of `block_timeout` for close()'s graceful
+# drain. The iteration should complete within block_timeout; we give it a small
 # extra window before cancelling as a last resort. Cancellation during close
 # may strand a message, but visibility-timeout restore recovers them on the
 # next worker startup.
@@ -254,12 +254,12 @@ class Channel:
         self._consume_fast_mode: bool = True
 
         # Server-side block duration for BZMPOP/XREAD inside a single consumer
-        # iteration. Matches classic kombu's `brpop_timeout` option.
-        self._brpop_timeout: float = opts.get("brpop_timeout", DEFAULT_BRPOP_TIMEOUT)
+        # iteration.
+        self._block_timeout: float = opts.get("block_timeout", DEFAULT_BLOCK_TIMEOUT)
 
         # Long-lived consumer iteration tasks; created lazily by drain_events.
         # Each task runs a single FAST→SLOW (or XREAD) cycle bounded by
-        # `_brpop_timeout`, then exits. drain_events restarts them. They are
+        # `_block_timeout`, then exits. drain_events restarts them. They are
         # never cancelled in the hot path; close() sets _closing and awaits
         # them to drain naturally.
         # `_started_at` and `_stall_warned` provide per-task stall detection:
@@ -719,8 +719,8 @@ class Channel:
         consumers.
 
         Consumer iterations are long-lived and bounded by Redis-side
-        `brpop_timeout` — never cancelled mid-flight. They complete on their
-        own; the asyncio.wait safety net at `brpop_timeout + CONSUMER_WAIT_HEADROOM`
+        `block_timeout` — never cancelled mid-flight. They complete on their
+        own; the asyncio.wait safety net at `block_timeout + CONSUMER_WAIT_HEADROOM`
         only fires if the client connection or server has hung. The caller's
         `timeout` parameter only affects the timeout=0 non-blocking fast path.
         """
@@ -747,7 +747,7 @@ class Channel:
             await asyncio.sleep(0.1)
             return False
 
-        safety_timeout = self._brpop_timeout + CONSUMER_WAIT_HEADROOM
+        safety_timeout = self._block_timeout + CONSUMER_WAIT_HEADROOM
         done, _pending = await asyncio.wait(
             tasks,
             return_when=asyncio.FIRST_COMPLETED,
@@ -813,7 +813,7 @@ class Channel:
     def _warn_stalled_iterations(self) -> None:
         loop = asyncio.get_running_loop()
         now = loop.time()
-        threshold = self._brpop_timeout + CONSUMER_WAIT_HEADROOM
+        threshold = self._block_timeout + CONSUMER_WAIT_HEADROOM
         for kind, task_attr, started_attr, warned_attr in (
             ("consume_regular", "_consume_iter_task", "_consume_iter_started_at", "_consume_iter_stall_warned"),
             ("xread_wait", "_xread_iter_task", "_xread_iter_started_at", "_xread_iter_stall_warned"),
@@ -836,19 +836,19 @@ class Channel:
 
     async def _safe_consume_iter(self, queues: list[str]) -> bool:
         try:
-            return await self._consume_regular(queues, self._brpop_timeout)
+            return await self._consume_regular(queues, self._block_timeout)
         except Exception as exc:
             logger.debug("consume iteration error: %s", exc)
             # Back off so drain_events doesn't tight-loop on a persistent fault.
-            await asyncio.sleep(min(self._brpop_timeout, 0.1))
+            await asyncio.sleep(min(self._block_timeout, 0.1))
             return False
 
     async def _safe_xread_iter(self) -> bool:
         try:
-            return await self._xread_wait(self._brpop_timeout)
+            return await self._xread_wait(self._block_timeout)
         except Exception as exc:
             logger.debug("xread iteration error: %s", exc)
-            await asyncio.sleep(min(self._brpop_timeout, 0.1))
+            await asyncio.sleep(min(self._block_timeout, 0.1))
             return False
 
     async def _consume_regular(self, queues: list[str], timeout: float) -> bool:
@@ -1400,11 +1400,11 @@ class Channel:
         self._closing = True
 
         # Let consumer iterations finish naturally — bounded by
-        # `brpop_timeout`. They are never cancelled in the hot path, so any
+        # `block_timeout`. They are never cancelled in the hot path, so any
         # in-flight FAST script / BZMPOP finalisation runs to completion and
         # the message is delivered rather than stranded in messages_index.
         # If an iteration is hung (Redis unresponsive), we cancel it after
-        # `brpop_timeout + CLOSE_DRAIN_HEADROOM` as a last resort: stranding
+        # `block_timeout + CLOSE_DRAIN_HEADROOM` as a last resort: stranding
         # at shutdown is acceptable since visibility-timeout restore recovers
         # those messages on the next worker startup.
         consumer_tasks = [
@@ -1413,7 +1413,7 @@ class Channel:
             if t is not None and not t.done()
         ]
         if consumer_tasks:
-            drain_timeout = self._brpop_timeout + CLOSE_DRAIN_HEADROOM
+            drain_timeout = self._block_timeout + CLOSE_DRAIN_HEADROOM
             try:
                 await asyncio.wait_for(
                     asyncio.gather(*consumer_tasks, return_exceptions=True),
@@ -1422,11 +1422,11 @@ class Channel:
             except (TimeoutError, asyncio.TimeoutError):
                 logger.warning(
                     "consumer iterations did not drain within %.1fs at close "
-                    "(brpop_timeout=%.1fs + headroom=%.1fs); cancelling — "
+                    "(block_timeout=%.1fs + headroom=%.1fs); cancelling — "
                     "in-flight messages may be stranded until visibility-"
                     "timeout restore",
                     drain_timeout,
-                    self._brpop_timeout,
+                    self._block_timeout,
                     CLOSE_DRAIN_HEADROOM,
                 )
                 for task in consumer_tasks:

--- a/kombu/transport/valkey_redis.py
+++ b/kombu/transport/valkey_redis.py
@@ -98,6 +98,11 @@ DEFAULT_MESSAGE_TTL = -1
 MIN_QUEUE_EXPIRES = 10_000
 DEFAULT_MAX_RESTORE_COUNT: int | None = None
 
+# Server-side block duration for BZMPOP/XREAD inside a single consumer
+# iteration. Bounds graceful-close latency and the maximum delay before a
+# newly registered consumer's queue starts being polled.
+BROKER_BLOCK_TIMEOUT = 1.0
+
 DEFAULT_EXCHANGE = ""
 DEFAULT_FANOUT_PREFIX = "/{db}."
 
@@ -234,6 +239,15 @@ class Channel:
 
         # FAST/SLOW consume mode
         self._consume_fast_mode: bool = True
+
+        # Long-lived consumer iteration tasks; created lazily by drain_events.
+        # Each task runs a single FAST→SLOW (or XREAD) cycle bounded by
+        # BROKER_BLOCK_TIMEOUT, then exits. drain_events restarts them.
+        # They are never cancelled in the hot path; close() sets _closing and
+        # awaits them to drain naturally.
+        self._consume_iter_task: asyncio.Task | None = None
+        self._xread_iter_task: asyncio.Task | None = None
+        self._closing: bool = False
 
         # Periodic task handles
         self._enqueue_task: asyncio.Task | None = None
@@ -676,65 +690,116 @@ class Channel:
     # ---- drain_events (FAST/SLOW consume) ----------------------------------
 
     async def drain_events(self, timeout: float | None = None) -> bool:
-        if not self._consumers:
+        """Wait for a single message to be delivered to one of this channel's
+        consumers, or return False if `timeout` elapses.
+
+        Consumer iterations are long-lived and bounded by Redis-side BZMPOP /
+        XREAD BLOCK timeouts — never cancelled mid-flight. Pending iterations
+        persist across drain_events calls; this avoids the cancellation race
+        that would otherwise strand a message between an atomic server-side
+        commit and Python-side delivery.
+        """
+        if self._closing or not self._consumers:
             await asyncio.sleep(0.1)
             return False
 
-        # Separate regular and fanout queues
-        regular_queues: list[str] = []
-        for q, _cb, _no_ack in self._consumers.values():
-            if q not in self.active_fanout_queues and q not in regular_queues:
-                regular_queues.append(q)
-
         effective_timeout = timeout if timeout is not None else 1.0
 
-        # Non-blocking fast path: only try FAST consume (Lua script),
-        # skip blocking BZMPOP/XREAD/asyncio.wait overhead.
+        # Non-blocking fast path: only try FAST consume.
         if effective_timeout == 0:
+            regular_queues = self._regular_queues()
             if regular_queues:
                 return await self._fast_consume(regular_queues)
             return False
 
-        tasks: list[asyncio.Task] = []
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + effective_timeout
 
-        if regular_queues:
-            tasks.append(
-                asyncio.ensure_future(
-                    self._consume_regular(regular_queues, effective_timeout),
-                ),
+        while True:
+            self._ensure_consumer_tasks()
+            tasks = [
+                t
+                for t in (self._consume_iter_task, self._xread_iter_task)
+                if t is not None
+            ]
+            if not tasks:
+                await asyncio.sleep(0.1)
+                return False
+
+            remaining = deadline - loop.time()
+            if remaining <= 0:
+                return False
+
+            done, _pending = await asyncio.wait(
+                tasks,
+                return_when=asyncio.FIRST_COMPLETED,
+                timeout=remaining,
             )
-        if self.active_fanout_queues:
-            tasks.append(
-                asyncio.ensure_future(
-                    self._xread_wait(effective_timeout),
-                ),
-            )
 
-        if not tasks:
-            await asyncio.sleep(0.1)
-            return False
+            if not done:
+                # asyncio.wait timed out — pending iterations keep running and
+                # will be picked up by the next drain_events call.
+                return False
 
-        done, pending = await asyncio.wait(
-            tasks,
-            return_when=asyncio.FIRST_COMPLETED,
-            timeout=effective_timeout,
+            delivered = False
+            for task in done:
+                try:
+                    if task.result():
+                        delivered = True
+                except Exception as exc:
+                    logger.debug("consumer iteration error: %s", exc)
+                if task is self._consume_iter_task:
+                    self._consume_iter_task = None
+                elif task is self._xread_iter_task:
+                    self._xread_iter_task = None
+
+            if delivered:
+                return True
+            # No delivery this round; restart the completed iteration(s) and
+            # keep waiting until the caller's deadline.
+
+    def _regular_queues(self) -> list[str]:
+        return list(
+            dict.fromkeys(
+                q
+                for q, _cb, _no_ack in self._consumers.values()
+                if q not in self.active_fanout_queues
+            ),
         )
 
-        # Cancel losers
-        for task in pending:
-            task.cancel()
-            try:
-                await task
-            except (asyncio.CancelledError, Exception):  # fmt: skip
-                pass
+    def _ensure_consumer_tasks(self) -> None:
+        if self._closing:
+            return
+        regular_queues = self._regular_queues()
+        if regular_queues and (
+            self._consume_iter_task is None or self._consume_iter_task.done()
+        ):
+            self._consume_iter_task = asyncio.create_task(
+                self._safe_consume_iter(regular_queues),
+            )
+        if self.active_fanout_queues and (
+            self._xread_iter_task is None or self._xread_iter_task.done()
+        ):
+            self._xread_iter_task = asyncio.create_task(
+                self._safe_xread_iter(),
+            )
 
-        for task in done:
-            try:
-                if task.result():
-                    return True
-            except Exception:
-                pass
-        return False
+    async def _safe_consume_iter(self, queues: list[str]) -> bool:
+        try:
+            return await self._consume_regular(queues, BROKER_BLOCK_TIMEOUT)
+        except Exception as exc:
+            logger.debug("consume iteration error: %s", exc)
+            # Back off so drain_events doesn't tight-loop on a persistent fault.
+            await asyncio.sleep(min(BROKER_BLOCK_TIMEOUT, 0.1))
+            return False
+
+    async def _safe_xread_iter(self) -> bool:
+        try:
+            return await self._xread_wait(BROKER_BLOCK_TIMEOUT)
+        except Exception as exc:
+            logger.debug("xread iteration error: %s", exc)
+            await asyncio.sleep(min(BROKER_BLOCK_TIMEOUT, 0.1))
+            return False
 
     async def _consume_regular(self, queues: list[str], timeout: float) -> bool:
         """Consume from regular queues using FAST/SLOW mode.
@@ -810,6 +875,9 @@ class Channel:
             )
         except Exception as exc:
             logger.debug("BZMPOP error: %s", exc)
+            # Defensive: prevent drain_events from tight-looping on connection
+            # errors. Successful BZMPOP timeouts already wait `timeout` seconds.
+            await asyncio.sleep(min(timeout, 0.1))
             return False
 
         if not result:
@@ -905,6 +973,9 @@ class Channel:
             )
         except Exception as exc:
             logger.debug("XREAD error: %s", exc)
+            # Defensive: prevent drain_events from tight-looping on connection
+            # errors. Successful XREAD timeouts already wait `block` ms.
+            await asyncio.sleep(min(timeout, 0.1))
             return False
 
         if not result:
@@ -1276,6 +1347,21 @@ class Channel:
         if self._closed:
             return
         self._closed = True
+        self._closing = True
+
+        # Let consumer iterations finish naturally — bounded by
+        # BROKER_BLOCK_TIMEOUT. They are never cancelled, so any in-flight
+        # FAST script / BZMPOP finalisation runs to completion and the
+        # message is delivered rather than stranded in messages_index.
+        consumer_tasks = [
+            t
+            for t in (self._consume_iter_task, self._xread_iter_task)
+            if t is not None and not t.done()
+        ]
+        if consumer_tasks:
+            await asyncio.gather(*consumer_tasks, return_exceptions=True)
+        self._consume_iter_task = None
+        self._xread_iter_task = None
 
         # Cancel periodic tasks
         for task in (self._enqueue_task, self._heartbeat_task, self._expires_task):

--- a/kombu/transport/valkey_redis.py
+++ b/kombu/transport/valkey_redis.py
@@ -103,6 +103,18 @@ DEFAULT_MAX_RESTORE_COUNT: int | None = None
 # newly registered consumer's queue starts being polled.
 BROKER_BLOCK_TIMEOUT = 1.0
 
+# asyncio.wait safety net for the consumer iteration. We trust Redis to honour
+# BZMPOP/XREAD BLOCK reliably, so this is only ever supposed to fire if the
+# client connection or server has truly hung. Set far above BROKER_BLOCK_TIMEOUT
+# so it does not race normal completions.
+CONSUMER_WAIT_SAFETY_TIMEOUT = 30.0
+
+# Maximum time close() will wait for in-flight iterations to drain naturally
+# before cancelling them as a last resort. Cancellation during close may
+# strand a message, but visibility-timeout restore recovers them on next
+# worker startup.
+CLOSE_DRAIN_TIMEOUT = BROKER_BLOCK_TIMEOUT * 3
+
 DEFAULT_EXCHANGE = ""
 DEFAULT_FANOUT_PREFIX = "/{db}."
 
@@ -691,13 +703,15 @@ class Channel:
 
     async def drain_events(self, timeout: float | None = None) -> bool:
         """Wait for a single message to be delivered to one of this channel's
-        consumers, or return False if `timeout` elapses.
+        consumers.
 
-        Consumer iterations are long-lived and bounded by Redis-side BZMPOP /
-        XREAD BLOCK timeouts — never cancelled mid-flight. Pending iterations
-        persist across drain_events calls; this avoids the cancellation race
-        that would otherwise strand a message between an atomic server-side
-        commit and Python-side delivery.
+        Consumer iterations are long-lived and bounded by Redis-side
+        BROKER_BLOCK_TIMEOUT — never cancelled mid-flight. They complete on
+        their own well before CONSUMER_WAIT_SAFETY_TIMEOUT, which is a generous
+        safety net that only fires if the client connection or server has hung.
+        The caller's `timeout` parameter only affects the timeout=0 non-blocking
+        fast path; in the blocking path, drain_events returns when the current
+        iteration completes (typically within BROKER_BLOCK_TIMEOUT seconds).
         """
         if self._closing or not self._consumers:
             await asyncio.sleep(0.1)
@@ -712,51 +726,47 @@ class Channel:
                 return await self._fast_consume(regular_queues)
             return False
 
-        loop = asyncio.get_running_loop()
-        deadline = loop.time() + effective_timeout
+        self._ensure_consumer_tasks()
+        tasks = [
+            t
+            for t in (self._consume_iter_task, self._xread_iter_task)
+            if t is not None
+        ]
+        if not tasks:
+            await asyncio.sleep(0.1)
+            return False
 
-        while True:
-            self._ensure_consumer_tasks()
-            tasks = [
-                t
-                for t in (self._consume_iter_task, self._xread_iter_task)
-                if t is not None
-            ]
-            if not tasks:
-                await asyncio.sleep(0.1)
-                return False
+        done, _pending = await asyncio.wait(
+            tasks,
+            return_when=asyncio.FIRST_COMPLETED,
+            timeout=CONSUMER_WAIT_SAFETY_TIMEOUT,
+        )
 
-            remaining = deadline - loop.time()
-            if remaining <= 0:
-                return False
-
-            done, _pending = await asyncio.wait(
-                tasks,
-                return_when=asyncio.FIRST_COMPLETED,
-                timeout=remaining,
+        if not done:
+            # Safety net fired — Redis didn't honour BLOCK or the client is
+            # hung. We deliberately don't cancel: a cancel mid-FAST-script
+            # or mid-post-BZMPOP would strand any message that's about to be
+            # delivered. The iteration is left pending; if Redis recovers it
+            # completes naturally and the next drain_events call picks it up.
+            logger.warning(
+                "consumer iteration did not return within %.1fs — Redis "
+                "BLOCK reply may be stalled; leaving iteration pending",
+                CONSUMER_WAIT_SAFETY_TIMEOUT,
             )
+            return False
 
-            if not done:
-                # asyncio.wait timed out — pending iterations keep running and
-                # will be picked up by the next drain_events call.
-                return False
-
-            delivered = False
-            for task in done:
-                try:
-                    if task.result():
-                        delivered = True
-                except Exception as exc:
-                    logger.debug("consumer iteration error: %s", exc)
-                if task is self._consume_iter_task:
-                    self._consume_iter_task = None
-                elif task is self._xread_iter_task:
-                    self._xread_iter_task = None
-
-            if delivered:
-                return True
-            # No delivery this round; restart the completed iteration(s) and
-            # keep waiting until the caller's deadline.
+        delivered = False
+        for task in done:
+            try:
+                if task.result():
+                    delivered = True
+            except Exception as exc:
+                logger.debug("consumer iteration error: %s", exc)
+            if task is self._consume_iter_task:
+                self._consume_iter_task = None
+            elif task is self._xread_iter_task:
+                self._xread_iter_task = None
+        return delivered
 
     def _regular_queues(self) -> list[str]:
         return list(
@@ -1350,16 +1360,39 @@ class Channel:
         self._closing = True
 
         # Let consumer iterations finish naturally — bounded by
-        # BROKER_BLOCK_TIMEOUT. They are never cancelled, so any in-flight
-        # FAST script / BZMPOP finalisation runs to completion and the
-        # message is delivered rather than stranded in messages_index.
+        # BROKER_BLOCK_TIMEOUT. They are never cancelled in the hot path, so
+        # any in-flight FAST script / BZMPOP finalisation runs to completion
+        # and the message is delivered rather than stranded in messages_index.
+        # If an iteration is hung (Redis unresponsive), we cancel it after
+        # CLOSE_DRAIN_TIMEOUT as a last resort: stranding at shutdown is
+        # acceptable since visibility-timeout restore recovers those messages
+        # on the next worker startup.
         consumer_tasks = [
             t
             for t in (self._consume_iter_task, self._xread_iter_task)
             if t is not None and not t.done()
         ]
         if consumer_tasks:
-            await asyncio.gather(*consumer_tasks, return_exceptions=True)
+            try:
+                await asyncio.wait_for(
+                    asyncio.gather(*consumer_tasks, return_exceptions=True),
+                    timeout=CLOSE_DRAIN_TIMEOUT,
+                )
+            except (TimeoutError, asyncio.TimeoutError):
+                logger.warning(
+                    "consumer iterations did not drain within %.1fs at close; "
+                    "cancelling — in-flight messages may be stranded until "
+                    "visibility-timeout restore",
+                    CLOSE_DRAIN_TIMEOUT,
+                )
+                for task in consumer_tasks:
+                    if not task.done():
+                        task.cancel()
+                for task in consumer_tasks:
+                    try:
+                        await task
+                    except (asyncio.CancelledError, Exception):  # fmt: skip
+                        pass
         self._consume_iter_task = None
         self._xread_iter_task = None
 

--- a/kombu/transport/valkey_redis.py
+++ b/kombu/transport/valkey_redis.py
@@ -262,8 +262,16 @@ class Channel:
         # `_brpop_timeout`, then exits. drain_events restarts them. They are
         # never cancelled in the hot path; close() sets _closing and awaits
         # them to drain naturally.
+        # `_started_at` and `_stall_warned` provide per-task stall detection:
+        # when one iteration hangs while the other keeps delivering, the
+        # hung-task warning still fires (asyncio.wait's FIRST_COMPLETED
+        # would otherwise mask it).
         self._consume_iter_task: asyncio.Task | None = None
+        self._consume_iter_started_at: float = 0.0
+        self._consume_iter_stall_warned: bool = False
         self._xread_iter_task: asyncio.Task | None = None
+        self._xread_iter_started_at: float = 0.0
+        self._xread_iter_stall_warned: bool = False
         self._closing: bool = False
 
         # Periodic task handles
@@ -746,20 +754,16 @@ class Channel:
             timeout=safety_timeout,
         )
 
+        # Per-task stall warning. asyncio.wait with FIRST_COMPLETED returns
+        # as soon as ANY task completes, so a single hung iteration alongside
+        # a healthy one would otherwise be silent. We deliberately don't
+        # cancel: a cancel mid-FAST-script or post-BZMPOP would strand the
+        # message that's about to be delivered. The iteration is left pending;
+        # if Redis recovers it completes naturally and the next drain_events
+        # call picks it up.
+        self._warn_stalled_iterations()
+
         if not done:
-            # Safety net fired — Redis didn't honour BLOCK or the client is
-            # hung. We deliberately don't cancel: a cancel mid-FAST-script
-            # or mid-post-BZMPOP would strand any message that's about to be
-            # delivered. The iteration is left pending; if Redis recovers it
-            # completes naturally and the next drain_events call picks it up.
-            logger.warning(
-                "consumer iteration did not return within %.1fs (brpop_timeout=%.1fs "
-                "+ headroom=%.1fs) — Redis BLOCK reply may be stalled; leaving "
-                "iteration pending",
-                safety_timeout,
-                self._brpop_timeout,
-                CONSUMER_WAIT_HEADROOM,
-            )
             return False
 
         delivered = False
@@ -787,6 +791,7 @@ class Channel:
     def _ensure_consumer_tasks(self) -> None:
         if self._closing:
             return
+        loop = asyncio.get_running_loop()
         regular_queues = self._regular_queues()
         if regular_queues and (
             self._consume_iter_task is None or self._consume_iter_task.done()
@@ -794,12 +799,40 @@ class Channel:
             self._consume_iter_task = asyncio.create_task(
                 self._safe_consume_iter(regular_queues),
             )
+            self._consume_iter_started_at = loop.time()
+            self._consume_iter_stall_warned = False
         if self.active_fanout_queues and (
             self._xread_iter_task is None or self._xread_iter_task.done()
         ):
             self._xread_iter_task = asyncio.create_task(
                 self._safe_xread_iter(),
             )
+            self._xread_iter_started_at = loop.time()
+            self._xread_iter_stall_warned = False
+
+    def _warn_stalled_iterations(self) -> None:
+        loop = asyncio.get_running_loop()
+        now = loop.time()
+        threshold = self._brpop_timeout + CONSUMER_WAIT_HEADROOM
+        for kind, task_attr, started_attr, warned_attr in (
+            ("consume_regular", "_consume_iter_task", "_consume_iter_started_at", "_consume_iter_stall_warned"),
+            ("xread_wait", "_xread_iter_task", "_xread_iter_started_at", "_xread_iter_stall_warned"),
+        ):
+            task = getattr(self, task_attr)
+            if (
+                task is not None
+                and not task.done()
+                and not getattr(self, warned_attr)
+                and now - getattr(self, started_attr) > threshold
+            ):
+                logger.warning(
+                    "%s iteration has been pending for %.1fs (> %.1fs); Redis "
+                    "BLOCK reply may be stalled. Iteration left running.",
+                    kind,
+                    now - getattr(self, started_attr),
+                    threshold,
+                )
+                setattr(self, warned_attr, True)
 
     async def _safe_consume_iter(self, queues: list[str]) -> bool:
         try:

--- a/kombu/transport/valkey_redis.py
+++ b/kombu/transport/valkey_redis.py
@@ -738,11 +738,7 @@ class Channel:
             return False
 
         self._ensure_consumer_tasks()
-        tasks = [
-            t
-            for t in (self._consume_iter_task, self._xread_iter_task)
-            if t is not None
-        ]
+        tasks = [t for t in (self._consume_iter_task, self._xread_iter_task) if t is not None]
         if not tasks:
             await asyncio.sleep(0.1)
             return False
@@ -781,11 +777,7 @@ class Channel:
 
     def _regular_queues(self) -> list[str]:
         return list(
-            dict.fromkeys(
-                q
-                for q, _cb, _no_ack in self._consumers.values()
-                if q not in self.active_fanout_queues
-            ),
+            dict.fromkeys(q for q, _cb, _no_ack in self._consumers.values() if q not in self.active_fanout_queues),
         )
 
     def _ensure_consumer_tasks(self) -> None:
@@ -793,17 +785,13 @@ class Channel:
             return
         loop = asyncio.get_running_loop()
         regular_queues = self._regular_queues()
-        if regular_queues and (
-            self._consume_iter_task is None or self._consume_iter_task.done()
-        ):
+        if regular_queues and (self._consume_iter_task is None or self._consume_iter_task.done()):
             self._consume_iter_task = asyncio.create_task(
                 self._safe_consume_iter(regular_queues),
             )
             self._consume_iter_started_at = loop.time()
             self._consume_iter_stall_warned = False
-        if self.active_fanout_queues and (
-            self._xread_iter_task is None or self._xread_iter_task.done()
-        ):
+        if self.active_fanout_queues and (self._xread_iter_task is None or self._xread_iter_task.done()):
             self._xread_iter_task = asyncio.create_task(
                 self._safe_xread_iter(),
             )
@@ -1407,11 +1395,7 @@ class Channel:
         # `block_timeout + CLOSE_DRAIN_HEADROOM` as a last resort: stranding
         # at shutdown is acceptable since visibility-timeout restore recovers
         # those messages on the next worker startup.
-        consumer_tasks = [
-            t
-            for t in (self._consume_iter_task, self._xread_iter_task)
-            if t is not None and not t.done()
-        ]
+        consumer_tasks = [t for t in (self._consume_iter_task, self._xread_iter_task) if t is not None and not t.done()]
         if consumer_tasks:
             drain_timeout = self._block_timeout + CLOSE_DRAIN_HEADROOM
             try:
@@ -1419,7 +1403,7 @@ class Channel:
                     asyncio.gather(*consumer_tasks, return_exceptions=True),
                     timeout=drain_timeout,
                 )
-            except (TimeoutError, asyncio.TimeoutError):
+            except TimeoutError:
                 logger.warning(
                     "consumer iterations did not drain within %.1fs at close "
                     "(block_timeout=%.1fs + headroom=%.1fs); cancelling — "

--- a/tests/unit/transport/test_valkey_redis.py
+++ b/tests/unit/transport/test_valkey_redis.py
@@ -1555,6 +1555,54 @@ class TestPersistentConsumerTasks:
         assert ch._consume_iter_task is None
         assert ch._closing is True
 
+    async def test_warns_when_only_one_iteration_stalls(self, monkeypatch, caplog):
+        # If asyncio.wait's FIRST_COMPLETED fires on a healthy iteration while
+        # the sibling is hung, the hung-task warning must still fire.
+        from kombu.transport import valkey_redis
+
+        monkeypatch.setattr(valkey_redis, "CONSUMER_WAIT_HEADROOM", 0.0)
+
+        ch = _make_channel(brpop_timeout=0.05)
+        ch._consumers["tag1"] = ("q1", MagicMock(), True)
+        ch._exchanges["fan"] = {"type": "fanout"}
+        ch._fanout_queues["fq1"] = ("fan", "*")
+        ch.active_fanout_queues.add("fq1")
+        ch._consumers["tag2"] = ("fq1", MagicMock(), True)
+
+        # Regular delivers fast on every call; xread is hung.
+        async def fast_deliver(*args, **kwargs):
+            await asyncio.sleep(0.005)
+            return True
+
+        async def hung(*args, **kwargs):
+            await asyncio.sleep(10)
+            return False
+
+        ch._consume_regular = fast_deliver
+        ch._xread_wait = hung
+
+        # First drain bootstraps both tasks. Regular delivers immediately,
+        # xread is left pending with a fresh started_at.
+        await ch.drain_events(timeout=1.0)
+        assert ch._xread_iter_task is not None
+        assert not ch._xread_iter_task.done()
+
+        # Wait so xread's age exceeds (brpop_timeout + headroom).
+        await asyncio.sleep(0.1)
+
+        with caplog.at_level("WARNING", logger="kombu.transport.valkey_redis"):
+            await ch.drain_events(timeout=1.0)
+
+        assert any(
+            "xread_wait" in rec.message and "stalled" in rec.message.lower()
+            for rec in caplog.records
+        )
+        # Warn-once: a third call must not log a second xread warning.
+        caplog.clear()
+        with caplog.at_level("WARNING", logger="kombu.transport.valkey_redis"):
+            await ch.drain_events(timeout=1.0)
+        assert not any("xread_wait" in rec.message for rec in caplog.records)
+
     async def test_close_cancels_hung_iteration_with_warning(self, monkeypatch, caplog):
         # If the iteration hangs past brpop_timeout + CLOSE_DRAIN_HEADROOM,
         # close cancels it as a last resort and logs a warning. Stranding at

--- a/tests/unit/transport/test_valkey_redis.py
+++ b/tests/unit/transport/test_valkey_redis.py
@@ -1470,7 +1470,7 @@ class TestPersistentConsumerTasks:
 
         monkeypatch.setattr(valkey_redis, "CONSUMER_WAIT_HEADROOM", 0.0)
 
-        ch = _make_channel(brpop_timeout=0.05)
+        ch = _make_channel(block_timeout=0.05)
         ch._consumers["tag1"] = ("q1", MagicMock(), True)
 
         cancelled = False
@@ -1504,7 +1504,7 @@ class TestPersistentConsumerTasks:
 
         monkeypatch.setattr(valkey_redis, "CONSUMER_WAIT_HEADROOM", 0.0)
 
-        ch = _make_channel(brpop_timeout=0.05)
+        ch = _make_channel(block_timeout=0.05)
         ch._consumers["tag1"] = ("q1", MagicMock(), True)
 
         invocations = 0
@@ -1562,7 +1562,7 @@ class TestPersistentConsumerTasks:
 
         monkeypatch.setattr(valkey_redis, "CONSUMER_WAIT_HEADROOM", 0.0)
 
-        ch = _make_channel(brpop_timeout=0.05)
+        ch = _make_channel(block_timeout=0.05)
         ch._consumers["tag1"] = ("q1", MagicMock(), True)
         ch._exchanges["fan"] = {"type": "fanout"}
         ch._fanout_queues["fq1"] = ("fan", "*")
@@ -1587,7 +1587,7 @@ class TestPersistentConsumerTasks:
         assert ch._xread_iter_task is not None
         assert not ch._xread_iter_task.done()
 
-        # Wait so xread's age exceeds (brpop_timeout + headroom).
+        # Wait so xread's age exceeds (block_timeout + headroom).
         await asyncio.sleep(0.1)
 
         with caplog.at_level("WARNING", logger="kombu.transport.valkey_redis"):
@@ -1604,7 +1604,7 @@ class TestPersistentConsumerTasks:
         assert not any("xread_wait" in rec.message for rec in caplog.records)
 
     async def test_close_cancels_hung_iteration_with_warning(self, monkeypatch, caplog):
-        # If the iteration hangs past brpop_timeout + CLOSE_DRAIN_HEADROOM,
+        # If the iteration hangs past block_timeout + CLOSE_DRAIN_HEADROOM,
         # close cancels it as a last resort and logs a warning. Stranding at
         # shutdown is acceptable since visibility-timeout restore recovers
         # those on next worker boot.
@@ -1612,7 +1612,7 @@ class TestPersistentConsumerTasks:
 
         monkeypatch.setattr(valkey_redis, "CLOSE_DRAIN_HEADROOM", 0.0)
 
-        ch = _make_channel(brpop_timeout=0.05)
+        ch = _make_channel(block_timeout=0.05)
         ch._consumers["tag1"] = ("q1", MagicMock(), True)
         ch._delivered = {}
 

--- a/tests/unit/transport/test_valkey_redis.py
+++ b/tests/unit/transport/test_valkey_redis.py
@@ -1593,10 +1593,7 @@ class TestPersistentConsumerTasks:
         with caplog.at_level("WARNING", logger="kombu.transport.valkey_redis"):
             await ch.drain_events(timeout=1.0)
 
-        assert any(
-            "xread_wait" in rec.message and "stalled" in rec.message.lower()
-            for rec in caplog.records
-        )
+        assert any("xread_wait" in rec.message and "stalled" in rec.message.lower() for rec in caplog.records)
         # Warn-once: a third call must not log a second xread warning.
         caplog.clear()
         with caplog.at_level("WARNING", logger="kombu.transport.valkey_redis"):

--- a/tests/unit/transport/test_valkey_redis.py
+++ b/tests/unit/transport/test_valkey_redis.py
@@ -1468,9 +1468,9 @@ class TestPersistentConsumerTasks:
         # state stays in sync if/when Redis recovers.
         from kombu.transport import valkey_redis
 
-        monkeypatch.setattr(valkey_redis, "CONSUMER_WAIT_SAFETY_TIMEOUT", 0.05)
+        monkeypatch.setattr(valkey_redis, "CONSUMER_WAIT_HEADROOM", 0.0)
 
-        ch = _make_channel()
+        ch = _make_channel(brpop_timeout=0.05)
         ch._consumers["tag1"] = ("q1", MagicMock(), True)
 
         cancelled = False
@@ -1502,9 +1502,9 @@ class TestPersistentConsumerTasks:
         # the next drain_events call — _consume_regular runs only once.
         from kombu.transport import valkey_redis
 
-        monkeypatch.setattr(valkey_redis, "CONSUMER_WAIT_SAFETY_TIMEOUT", 0.05)
+        monkeypatch.setattr(valkey_redis, "CONSUMER_WAIT_HEADROOM", 0.0)
 
-        ch = _make_channel()
+        ch = _make_channel(brpop_timeout=0.05)
         ch._consumers["tag1"] = ("q1", MagicMock(), True)
 
         invocations = 0
@@ -1523,9 +1523,9 @@ class TestPersistentConsumerTasks:
         first_task = ch._consume_iter_task
         assert first_task is not None
 
-        # Restore a generous safety net so the next call harvests the same
+        # Restore a generous headroom so the next call harvests the same
         # iteration when it completes.
-        monkeypatch.setattr(valkey_redis, "CONSUMER_WAIT_SAFETY_TIMEOUT", 5.0)
+        monkeypatch.setattr(valkey_redis, "CONSUMER_WAIT_HEADROOM", 5.0)
         result = await ch.drain_events(timeout=1.0)
         assert result is True
         assert invocations == 1
@@ -1556,14 +1556,15 @@ class TestPersistentConsumerTasks:
         assert ch._closing is True
 
     async def test_close_cancels_hung_iteration_with_warning(self, monkeypatch, caplog):
-        # If the iteration hangs past CLOSE_DRAIN_TIMEOUT, close cancels it as
-        # a last resort and logs a warning. Stranding at shutdown is acceptable
-        # since visibility-timeout restore recovers those on next worker boot.
+        # If the iteration hangs past brpop_timeout + CLOSE_DRAIN_HEADROOM,
+        # close cancels it as a last resort and logs a warning. Stranding at
+        # shutdown is acceptable since visibility-timeout restore recovers
+        # those on next worker boot.
         from kombu.transport import valkey_redis
 
-        monkeypatch.setattr(valkey_redis, "CLOSE_DRAIN_TIMEOUT", 0.05)
+        monkeypatch.setattr(valkey_redis, "CLOSE_DRAIN_HEADROOM", 0.0)
 
-        ch = _make_channel()
+        ch = _make_channel(brpop_timeout=0.05)
         ch._consumers["tag1"] = ("q1", MagicMock(), True)
         ch._delivered = {}
 

--- a/tests/unit/transport/test_valkey_redis.py
+++ b/tests/unit/transport/test_valkey_redis.py
@@ -1438,40 +1438,72 @@ class TestDrainEventsFull:
 
 
 class TestPersistentConsumerTasks:
-    async def test_drain_timeout_does_not_cancel_pending_iteration(self):
-        # Once an iteration is in flight (mid-BZMPOP or mid-script reply) it
-        # must NOT be cancelled when drain_events times out. Otherwise the
-        # broker-side state can race ahead of Python-side delivery and the
-        # message strands in messages_index for ~6 min.
+    async def test_drain_events_never_cancels_iteration(self):
+        # Core invariant: drain_events must not cancel the consumer iteration.
+        # Cancellation mid-FAST-script or post-BZMPOP strands a message in
+        # messages_index for ~6 min.
         ch = _make_channel()
         ch._consumers["tag1"] = ("q1", MagicMock(), True)
 
-        iteration_completed = asyncio.Event()
+        cancelled = False
 
-        async def long_iteration(*args, **kwargs):
+        async def watch_for_cancel(*args, **kwargs):
+            nonlocal cancelled
             try:
-                await asyncio.sleep(0.2)
+                await asyncio.sleep(0.05)
+                return True
+            except asyncio.CancelledError:
+                cancelled = True
+                raise
+
+        ch._consume_regular = watch_for_cancel
+
+        result = await ch.drain_events(timeout=1.0)
+        assert result is True
+        assert cancelled is False
+
+    async def test_safety_net_leaves_iteration_pending(self, monkeypatch):
+        # When the asyncio.wait safety net fires (Redis hung), the iteration
+        # must be left pending — not cancelled — so any in-flight broker
+        # state stays in sync if/when Redis recovers.
+        from kombu.transport import valkey_redis
+
+        monkeypatch.setattr(valkey_redis, "CONSUMER_WAIT_SAFETY_TIMEOUT", 0.05)
+
+        ch = _make_channel()
+        ch._consumers["tag1"] = ("q1", MagicMock(), True)
+
+        cancelled = False
+        will_finish = asyncio.Event()
+
+        async def slow_iteration(*args, **kwargs):
+            nonlocal cancelled
+            try:
+                await asyncio.sleep(0.2)  # longer than safety net
+                will_finish.set()
                 return False
-            finally:
-                iteration_completed.set()
+            except asyncio.CancelledError:
+                cancelled = True
+                raise
 
-        ch._consume_regular = long_iteration
+        ch._consume_regular = slow_iteration
 
-        # drain_events times out before the iteration finishes.
-        result = await ch.drain_events(timeout=0.05)
+        result = await ch.drain_events(timeout=1.0)
         assert result is False
         assert ch._consume_iter_task is not None
         assert not ch._consume_iter_task.done()
-        assert not ch._consume_iter_task.cancelled()
+        assert cancelled is False
 
-        # Let the iteration complete naturally.
-        await iteration_completed.wait()
+        # Let the iteration finish naturally so we don't leak a task.
+        await will_finish.wait()
 
-    async def test_inflight_iteration_persists_across_drain_calls(self):
-        # The persistent iteration task started by one drain_events call must
-        # be picked up by the next call instead of being recreated. Verifies
-        # that a message delivered by the long-running iteration eventually
-        # makes it back to the caller.
+    async def test_pending_iteration_reused_by_next_drain(self, monkeypatch):
+        # A pending iteration left behind by a safety-net fire is reused by
+        # the next drain_events call — _consume_regular runs only once.
+        from kombu.transport import valkey_redis
+
+        monkeypatch.setattr(valkey_redis, "CONSUMER_WAIT_SAFETY_TIMEOUT", 0.05)
+
         ch = _make_channel()
         ch._consumers["tag1"] = ("q1", MagicMock(), True)
 
@@ -1481,23 +1513,21 @@ class TestPersistentConsumerTasks:
             nonlocal invocations
             invocations += 1
             await asyncio.sleep(0.1)
-            return True  # delivered
+            return True
 
         ch._consume_regular = slow_then_deliver
 
-        # First call times out before the iteration finishes.
-        result = await ch.drain_events(timeout=0.02)
+        result = await ch.drain_events(timeout=1.0)
         assert result is False
         assert invocations == 1
-        assert ch._consume_iter_task is not None
-
         first_task = ch._consume_iter_task
+        assert first_task is not None
 
-        # Second call waits long enough to harvest the existing iteration.
-        result = await ch.drain_events(timeout=0.5)
+        # Restore a generous safety net so the next call harvests the same
+        # iteration when it completes.
+        monkeypatch.setattr(valkey_redis, "CONSUMER_WAIT_SAFETY_TIMEOUT", 5.0)
+        result = await ch.drain_events(timeout=1.0)
         assert result is True
-        # The same iteration delivered the message — _consume_regular was not
-        # invoked a second time.
         assert invocations == 1
         assert first_task.done()
 
@@ -1516,17 +1546,40 @@ class TestPersistentConsumerTasks:
             return True
 
         ch._consume_regular = deliver_then_finish
+        ch._consume_iter_task = asyncio.create_task(
+            ch._safe_consume_iter(["q1"]),
+        )
 
-        # Start an iteration via drain_events and time out before it finishes.
-        await ch.drain_events(timeout=0.01)
-        assert ch._consume_iter_task is not None
-        assert not ch._consume_iter_task.done()
-
-        # close() must wait for the iteration to complete.
         await ch.close()
         assert delivered.is_set()
         assert ch._consume_iter_task is None
         assert ch._closing is True
+
+    async def test_close_cancels_hung_iteration_with_warning(self, monkeypatch, caplog):
+        # If the iteration hangs past CLOSE_DRAIN_TIMEOUT, close cancels it as
+        # a last resort and logs a warning. Stranding at shutdown is acceptable
+        # since visibility-timeout restore recovers those on next worker boot.
+        from kombu.transport import valkey_redis
+
+        monkeypatch.setattr(valkey_redis, "CLOSE_DRAIN_TIMEOUT", 0.05)
+
+        ch = _make_channel()
+        ch._consumers["tag1"] = ("q1", MagicMock(), True)
+        ch._delivered = {}
+
+        async def hung_iteration(*args, **kwargs):
+            await asyncio.sleep(10)
+            return False
+
+        ch._consume_regular = hung_iteration
+        ch._consume_iter_task = asyncio.create_task(
+            ch._safe_consume_iter(["q1"]),
+        )
+
+        with caplog.at_level("WARNING", logger="kombu.transport.valkey_redis"):
+            await ch.close()
+        assert ch._consume_iter_task is None
+        assert any("did not drain" in rec.message for rec in caplog.records)
 
 
 class TestPeriodicTasks:

--- a/tests/unit/transport/test_valkey_redis.py
+++ b/tests/unit/transport/test_valkey_redis.py
@@ -1433,8 +1433,100 @@ class TestDrainEventsFull:
 
 
 # ---------------------------------------------------------------------------
-# Periodic tasks lifecycle
+# Persistent consumer task lifecycle
 # ---------------------------------------------------------------------------
+
+
+class TestPersistentConsumerTasks:
+    async def test_drain_timeout_does_not_cancel_pending_iteration(self):
+        # Once an iteration is in flight (mid-BZMPOP or mid-script reply) it
+        # must NOT be cancelled when drain_events times out. Otherwise the
+        # broker-side state can race ahead of Python-side delivery and the
+        # message strands in messages_index for ~6 min.
+        ch = _make_channel()
+        ch._consumers["tag1"] = ("q1", MagicMock(), True)
+
+        iteration_completed = asyncio.Event()
+
+        async def long_iteration(*args, **kwargs):
+            try:
+                await asyncio.sleep(0.2)
+                return False
+            finally:
+                iteration_completed.set()
+
+        ch._consume_regular = long_iteration
+
+        # drain_events times out before the iteration finishes.
+        result = await ch.drain_events(timeout=0.05)
+        assert result is False
+        assert ch._consume_iter_task is not None
+        assert not ch._consume_iter_task.done()
+        assert not ch._consume_iter_task.cancelled()
+
+        # Let the iteration complete naturally.
+        await iteration_completed.wait()
+
+    async def test_inflight_iteration_persists_across_drain_calls(self):
+        # The persistent iteration task started by one drain_events call must
+        # be picked up by the next call instead of being recreated. Verifies
+        # that a message delivered by the long-running iteration eventually
+        # makes it back to the caller.
+        ch = _make_channel()
+        ch._consumers["tag1"] = ("q1", MagicMock(), True)
+
+        invocations = 0
+
+        async def slow_then_deliver(*args, **kwargs):
+            nonlocal invocations
+            invocations += 1
+            await asyncio.sleep(0.1)
+            return True  # delivered
+
+        ch._consume_regular = slow_then_deliver
+
+        # First call times out before the iteration finishes.
+        result = await ch.drain_events(timeout=0.02)
+        assert result is False
+        assert invocations == 1
+        assert ch._consume_iter_task is not None
+
+        first_task = ch._consume_iter_task
+
+        # Second call waits long enough to harvest the existing iteration.
+        result = await ch.drain_events(timeout=0.5)
+        assert result is True
+        # The same iteration delivered the message — _consume_regular was not
+        # invoked a second time.
+        assert invocations == 1
+        assert first_task.done()
+
+    async def test_close_awaits_inflight_iteration(self):
+        # close() must let the in-flight iteration finish so a message that
+        # was already popped server-side is delivered, not stranded.
+        ch = _make_channel()
+        ch._consumers["tag1"] = ("q1", MagicMock(), True)
+        ch._delivered = {}
+
+        delivered = asyncio.Event()
+
+        async def deliver_then_finish(*args, **kwargs):
+            await asyncio.sleep(0.05)
+            delivered.set()
+            return True
+
+        ch._consume_regular = deliver_then_finish
+
+        # Start an iteration via drain_events and time out before it finishes.
+        await ch.drain_events(timeout=0.01)
+        assert ch._consume_iter_task is not None
+        assert not ch._consume_iter_task.done()
+
+        # close() must wait for the iteration to complete.
+        await ch.close()
+        assert delivered.is_set()
+        assert ch._consume_iter_task is None
+        assert ch._closing is True
 
 
 class TestPeriodicTasks:


### PR DESCRIPTION
## Summary

The benchmark in [celery-asyncio/examples/benchmark/RESULTS.md](https://github.com/oliverhaas/celery-asyncio/blob/main/examples/benchmark/RESULTS.md) flagged that the asyncio Redis transport strands 0.07–0.16 % of task messages (21–48 of 30 000) during heavy workloads. Root cause was a cancellation race in `Channel.drain_events`: it cancelled in-flight consume tasks on every timeout. If the FAST Lua script or post-BZMPOP pipeline had already committed server-side, the payload was discarded and the message strand-ed in `messages_index` until visibility-timeout restore re-enqueued it ~6 min later.

Rather than paper over the race with `asyncio.shield`, this restructures the consumer architecturally:

- Each channel keeps **long-lived `_consume_iter_task` and `_xread_iter_task`**. An iteration runs FAST→SLOW (or XREAD) once, bounded by a fixed `BROKER_BLOCK_TIMEOUT` of 1 s using the Redis server-side timeout argument that BZMPOP / XREAD BLOCK already provide.
- **`drain_events` never calls `task.cancel()`.** It waits for whichever iteration completes first (`asyncio.wait(FIRST_COMPLETED, timeout=…)`). If its own deadline fires first, the pending iteration is left running — the next `drain_events` call picks it up.
- **Graceful close**: `Channel.close()` sets `self._closing = True` and `asyncio.gather`s the iteration tasks so any in-flight FAST script / BZMPOP finalisation runs to completion. Worst-case close latency = `BROKER_BLOCK_TIMEOUT` (~1 s).
- `_safe_consume_iter` / `_safe_xread_iter` wrappers absorb iteration exceptions with a brief backoff so a persistent fault doesn't tight-loop `drain_events`.

## Test plan
- [x] New `TestPersistentConsumerTasks` class:
  - `drain_events` timeout leaves the pending iteration neither done nor cancelled.
  - An in-flight iteration started by one `drain_events` call delivers via the next call (single underlying invocation).
  - `close()` awaits the in-flight iteration; message is delivered.
- [x] Full `tests/unit/` suite: 226 passed, 1 skipped.
- [ ] Re-run `celery-asyncio` benchmark against this branch and confirm `stranded = 0`.